### PR TITLE
Increase tooltip visibility

### DIFF
--- a/deepOcean/themes/Material-DeepOcean-B-LB/gtk-3.0/gtk.css
+++ b/deepOcean/themes/Material-DeepOcean-B-LB/gtk-3.0/gtk.css
@@ -5839,6 +5839,11 @@ tooltip > box {
   padding: 4px 8px;
 }
 
+tooltip * {
+  background-color: transparent;
+  color: #ffffff; 
+}
+
 /*****************
  * Color Chooser *
  *****************/

--- a/deepOcean/themes/Material-DeepOcean-B/gtk-3.0/gtk.css
+++ b/deepOcean/themes/Material-DeepOcean-B/gtk-3.0/gtk.css
@@ -5839,6 +5839,11 @@ tooltip > box {
   padding: 4px 8px;
 }
 
+tooltip * {
+  background-color: transparent;
+  color: #ffffff; 
+}
+
 /*****************
  * Color Chooser *
  *****************/

--- a/deepOcean/themes/Material-DeepOcean-BL-LB/gtk-3.0/gtk.css
+++ b/deepOcean/themes/Material-DeepOcean-BL-LB/gtk-3.0/gtk.css
@@ -5847,6 +5847,11 @@ tooltip > box {
   padding: 4px 8px;
 }
 
+tooltip * {
+  background-color: transparent;
+  color: #ffffff; 
+}
+
 /*****************
  * Color Chooser *
  *****************/

--- a/deepOcean/themes/Material-DeepOcean-BL/gtk-3.0/gtk.css
+++ b/deepOcean/themes/Material-DeepOcean-BL/gtk-3.0/gtk.css
@@ -5847,6 +5847,11 @@ tooltip > box {
   padding: 4px 8px;
 }
 
+tooltip * {
+  background-color: transparent;
+  color: #ffffff; 
+}
+
 /*****************
  * Color Chooser *
  *****************/


### PR DESCRIPTION
I have noticed very bad tooltip text visibility on cinnamon gtk3 with the deep ocean theme.
This piece of code sets tooltip text color to white, thus, increases visibility.
```css
tooltip * {
  background-color: transparent;
  color: #ffffff; 
}
```